### PR TITLE
Remove unused logging configurations

### DIFF
--- a/ml/loggers/base.py
+++ b/ml/loggers/base.py
@@ -212,6 +212,8 @@ def standardize_images(
     """
 
     if normalize and images.is_floating_point():
+        if images.is_mps:
+            images = images.cpu()  # aminmax not supported for MPS devices.
         minv, maxv = images.aminmax()
         maxv.clamp_min_(1.0)
         minv.clamp_max_(0.0)

--- a/ml/loggers/base.py
+++ b/ml/loggers/base.py
@@ -160,7 +160,8 @@ class BaseLogger(BaseObjectWithPointers[LoggerConfigT], Generic[LoggerConfigT], 
 
 def _aminmax(t: Tensor) -> Tuple[Tensor, Tensor]:
     # `aminmax` isn't supported for MPS tensors, fall back to separate calls.
-    return (t.min(), t.max()) if t.is_mps else tuple(t.aminmax())
+    minv, maxv = (t.min(), t.max()) if t.is_mps else tuple(t.aminmax())
+    return minv, maxv
 
 
 def standardize_image(image: Tensor, *, log_key: str | None = None, normalize: bool = True) -> Tensor:

--- a/ml/tasks/base.py
+++ b/ml/tasks/base.py
@@ -187,13 +187,6 @@ class FinishTrainingConfig:
 
 
 @dataclass
-class LoggingConfig:
-    train_log_interval: int = conf_field(100, help="How often to log train images")
-    valid_log_interval: int = conf_field(1, help="How often to log validation images")
-    test_log_interval: int = conf_field(1, help="How often to log test images")
-
-
-@dataclass
 class LossConfig:
     reduce_type: str = conf_field("mean", help="Loss reduction type to use")
 
@@ -204,7 +197,6 @@ class BaseTaskConfig(BaseConfig):
 
     dataloader: Dict[str, DataLoaderConfig] = conf_field(lambda: DEFAULT_DATALOADER_CONFIGS)
     finished: FinishTrainingConfig = FinishTrainingConfig()
-    logging: LoggingConfig = LoggingConfig()
     error_handling: ErrorHandlingConfig = ErrorHandlingConfig()
     loss: LossConfig = LossConfig()
 
@@ -236,18 +228,6 @@ class BaseTask(nn.Module, BaseObjectWithPointers[TaskConfigT], Generic[TaskConfi
 
         # Final loss reduce type.
         self.__final_loss_reduce_type = cast_reduce_type(self.config.loss.reduce_type)
-
-    def should_log_train(self, state: State) -> bool:
-        return state.phase == "train" and state.num_steps % self.config.logging.train_log_interval == 0
-
-    def should_log_valid(self, state: State) -> bool:
-        return state.phase == "valid" and state.num_valid_steps % self.config.logging.valid_log_interval == 0
-
-    def should_log_test(self, state: State) -> bool:
-        return state.phase == "test" and state.num_test_steps % self.config.logging.test_log_interval == 0
-
-    def should_log(self, state: State) -> bool:
-        return self.should_log_train(state) or self.should_log_valid(state) or self.should_log_test(state)
 
     @abstractmethod
     def run_model(self, model: BaseModel, batch: Batch, state: State) -> Output:

--- a/ml/tasks/cifar_demo.py
+++ b/ml/tasks/cifar_demo.py
@@ -36,7 +36,12 @@ class CIFARDemoTask(BaseTask[CIFARDemoTaskConfig]):
         state: State,
         output: Tensor,
     ) -> Tensor:
-        (_, classes), preds = batch, output
+        (image, classes), preds = batch, output
+
+        # Logs training and validation images using each logger.
+        if state.phase in ("valid", "test"):
+            self.logger.log_images("image", image)
+
         return F.cross_entropy(preds, classes.flatten().long(), reduction="none")
 
     def get_dataset(self, phase: Phase) -> Dataset:

--- a/ml/trainers/base.py
+++ b/ml/trainers/base.py
@@ -213,7 +213,7 @@ def save_config(exp_dir: Path, raw_config: DictConfig) -> None:
 
 
 @dataclass
-class LoggingConfig:
+class ValidationConfig:
     valid_every_n_steps: Optional[int] = conf_field(100, help="Number of training steps to run per test step")
     num_init_valid_steps: Optional[int] = conf_field(2, help="Number of initial validation steps")
 
@@ -232,7 +232,7 @@ class BaseTrainerConfig(BaseConfig):
     log_dir_name: str = conf_field("logs", help="Name of the subdirectory which contains logs")
     base_run_dir: str = conf_field(II("resolve:${oc.env:RUN_DIR}"), help="The base directory for all runs")
     run_id: int = conf_field(MISSING, help="The run ID to use")
-    logging: LoggingConfig = LoggingConfig()
+    validation: ValidationConfig = ValidationConfig()
     checkpoint: CheckpointConfig = CheckpointConfig()
 
     @classmethod
@@ -256,7 +256,6 @@ class BaseTrainer(BaseObjectWithPointers[TrainerConfigT], Generic[TrainerConfigT
 
         self.exp_dir = get_exp_dir(Path(config.base_run_dir), config.exp_name, config.run_id)
         self.log_dir = self.exp_dir / config.log_dir_name
-        self.logging_config = config.logging
         self.checkpoint_config = config.checkpoint
         self.loggers = []
         self.logger = MultiLogger(default_namespace="trainer")

--- a/ml/trainers/vanilla.py
+++ b/ml/trainers/vanilla.py
@@ -268,7 +268,7 @@ class VanillaTrainer(
                 if profile is not None:
                     ctx.enter_context(profile)
 
-                if (num_init_valid_steps := self.logging_config.num_init_valid_steps) is not None:
+                if (num_init_valid_steps := self.config.validation.num_init_valid_steps) is not None:
                     for _ in range(num_init_valid_steps):
                         self.val_step(
                             task_model=task_model,
@@ -302,7 +302,7 @@ class VanillaTrainer(
                             lr_sched=lr_sched,
                         )
 
-                        valid_every_n_steps = self.logging_config.valid_every_n_steps
+                        valid_every_n_steps = self.config.validation.valid_every_n_steps
                         if valid_every_n_steps is not None and state.num_steps % valid_every_n_steps == 0:
                             self.val_step(
                                 task_model=task_model,


### PR DESCRIPTION
## Description

- The logging configuration stuff isn't very useful. Removing it
- Fix a small issue with image logging on MPS

## Test Plan

- Ran the CIFAR example to make sure it still works

```bash
ml train configs/cifar_demo.yaml
```
