### PR TITLE
Pass callables to loggers instead of concrete values

### DIFF
--- a/ml/tasks/base.py
+++ b/ml/tasks/base.py
@@ -268,8 +268,8 @@ class BaseTask(nn.Module, BaseObjectWithPointers[TaskConfigT], Generic[TaskConfi
                 same shape.
 
         Returns:
-            The single loss with shape (N, B), where N is the number of losses
-            and B is the batch size, and the loss names, a list of length N.
+            The single loss with shape (N), where N is the number of losses,
+            and the loss names, a list of length N.
         """
 
         if isinstance(loss, Tensor):
@@ -280,7 +280,7 @@ class BaseTask(nn.Module, BaseObjectWithPointers[TaskConfigT], Generic[TaskConfi
             assert loss_tensor.ndim >= 1, f"Loss {key} must not be a scalar"
         keys = list(sorted(loss.keys()))
         single_loss = torch.stack([loss[k] for k in keys], dim=0)
-        single_loss = reduce(single_loss.flatten(1), self.__final_loss_reduce_type, 0)
+        single_loss = reduce(single_loss.flatten(1), self.__final_loss_reduce_type, 1)
         return single_loss, keys
 
     def log_loss_dict(self, loss: Mapping[str, int | float | Tensor], state: State) -> None:

--- a/ml/tasks/cifar_demo.py
+++ b/ml/tasks/cifar_demo.py
@@ -38,7 +38,12 @@ class CIFARDemoTask(BaseTask[CIFARDemoTaskConfig]):
     ) -> Tensor:
         (image, classes), preds = batch, output
 
-        # Logs training and validation images using each logger.
+        # Passing in a callable function ensures that we don't compute the
+        # metric unless it's going to be logged, for example, when the logger
+        # is rate-limited.
+        self.logger.log_scalar("accuracy", lambda: (classes == preds.argmax(dim=1, keepdim=True)).float().mean())
+
+        # On validation and test steps, logs images to each image logger.
         if state.phase in ("valid", "test"):
             self.logger.log_images("image", image)
 


### PR DESCRIPTION
## Description

- Passing callables to each logger, instead of concrete values, to avoid unused computation
- Also fixed a logging error with the loss function

## Test Plan

- It doesn't seem like there's a memory leak with the GPU job I started
