### PR TITLE
Add async iterable dataset and video loading

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PYTHONPATH=.

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.py[oc]
 __pycache__/
 *.egg-info
+.eggs/
 
 # Databases
 *.db

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ endif
 
 install-deps: initialize
 	@mamba install $(CONDA_CHANNELS) $(CONDA_DEPS)
-.PHONY: install-dependencies
+.PHONY: install-deps
 
 install: initialize
 	@TORCH_VERSION=$(TORCH_VERSION) TORCHVISION_VERSION=$(TORCHVISION_VERSION) pip install $(PIP_ARGS) -e .

--- a/ml/tasks/datasets/async_iterable.py
+++ b/ml/tasks/datasets/async_iterable.py
@@ -1,0 +1,59 @@
+import asyncio
+import queue
+import threading
+from typing import AsyncIterator, Iterator, Optional, TypeVar
+
+from torch.utils.data.dataset import IterableDataset
+
+T = TypeVar("T")
+
+
+def iter_async_items(
+    async_iter: AsyncIterator[T],
+    loop: asyncio.AbstractEventLoop,
+    max_queue_size: int,
+) -> Iterator[T]:
+    q: "queue.Queue[Optional[T]]" = queue.Queue(maxsize=max_queue_size)
+
+    async def async_iter_to_queue() -> None:
+        try:
+            async for item in async_iter:
+                q.put(item)
+        finally:
+            q.put(None)
+
+    async_result = asyncio.run_coroutine_threadsafe(async_iter_to_queue(), loop)
+
+    def yield_queue_items() -> Iterator[T]:
+        while True:
+            next_item = q.get()
+            if next_item is None:
+                break
+            yield next_item
+        async_result.result()
+
+    return yield_queue_items()
+
+
+class AsyncIterableDataset(IterableDataset[T]):
+    def __init__(self, max_async_queue_size: int = 2) -> None:
+        super().__init__()
+
+        # The async iterator blocks on the queue if it has more than this many
+        # elements, in order to avoid having the queue get too large.
+        self.max_async_queue_size = max_async_queue_size
+
+        # Placeholders for the async loop and thread.
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
+        self.thread: Optional[threading.Thread] = None
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        raise NotImplementedError
+
+    def __iter__(self) -> Iterator[T]:
+        if self.loop is None:
+            self.loop = asyncio.get_event_loop()
+        if self.thread is None:
+            self.thread = threading.Thread(target=self.loop.run_forever, daemon=True)
+            self.thread.start()
+        return iter_async_items(self.__aiter__(), self.loop, self.max_async_queue_size)

--- a/ml/utils/video.py
+++ b/ml/utils/video.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import asyncio
+import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Iterator, Literal, Optional
+from typing import AsyncGenerator, Callable, Dict, Iterator, Literal, Optional, Tuple
 
 import cv2
 import ffmpeg
@@ -88,6 +90,60 @@ def read_video_ffmpeg(
 
     stream.stdout.close()
     stream.wait()
+
+
+async def read_video_with_timestamps_ffmpeg(
+    in_file: str | Path,
+    output_fmt: str = "rgb24",
+    channels: int = 3,
+) -> AsyncGenerator[Tuple[np.ndarray, float], None]:
+    """Like `read_video_ffmpeg` but also returns timestamps.
+    Args:
+        in_file: The input video to read
+        output_fmt: The output image format
+        channels: Number of output channels for each video frame
+    Yields:
+        Frames from the video as numpy arrays with shape (H, W, C), along with
+        the frame timestamps
+    """
+
+    props = VideoProps.from_file_ffmpeg(in_file)
+
+    stream = ffmpeg.input(str(in_file))
+    stream = ffmpeg.output(stream, "pipe:", format="rawvideo", pix_fmt=output_fmt, r=props.fps, vf="showinfo")
+    stream = ffmpeg.run_async(stream, pipe_stdout=True, pipe_stderr=True)
+
+    async def gen_frames() -> AsyncGenerator[np.ndarray, None]:
+        while True:
+            in_bytes = stream.stdout.read(props.frame_width * props.frame_height * channels)
+            if not in_bytes:
+                raise StopAsyncIteration
+            frame = np.frombuffer(in_bytes, np.uint8).reshape((props.frame_height, props.frame_width, channels))
+            yield frame
+
+    async def gen_timestamps() -> AsyncGenerator[float, None]:
+        exp = re.compile(rb"n:\s*(\d+)\s*pts:\s*(\d+)\s*pts_time:\s*([\d\.]+)")
+        while True:
+            in_line = stream.stderr.readline()
+            if not in_line:
+                raise StopAsyncIteration
+            exp_match = exp.search(in_line)
+            if exp_match is None:
+                continue
+            _, _, pts_time = exp_match.groups()
+            yield float(pts_time.decode("utf-8"))
+
+    frame_iter, ts_iter = gen_frames(), gen_timestamps()
+
+    try:
+        while True:
+            frame, ts = await asyncio.gather(frame_iter.__anext__(), ts_iter.__anext__())
+            yield frame, ts
+
+    except StopAsyncIteration:
+        stream.stdout.close()
+        stream.stderr.close()
+        stream.wait()
 
 
 def read_video_opencv(in_file: str | Path) -> Iterator[np.ndarray]:

--- a/ml/utils/video.py
+++ b/ml/utils/video.py
@@ -98,10 +98,12 @@ async def read_video_with_timestamps_ffmpeg(
     channels: int = 3,
 ) -> AsyncGenerator[Tuple[np.ndarray, float], None]:
     """Like `read_video_ffmpeg` but also returns timestamps.
+
     Args:
         in_file: The input video to read
         output_fmt: The output image format
         channels: Number of output channels for each video frame
+
     Yields:
         Frames from the video as numpy arrays with shape (H, W, C), along with
         the frame timestamps

--- a/tests/tasks/datasets/test_async_iterable.py
+++ b/tests/tasks/datasets/test_async_iterable.py
@@ -1,0 +1,32 @@
+import asyncio
+from typing import AsyncIterator
+
+import torch
+from torch.utils.data.dataloader import DataLoader
+
+from ml.tasks.datasets.async_iterable import AsyncIterableDataset
+
+
+def test_dataset() -> None:
+    """Tests functioning of async iterable dataset."""
+
+    class DummyDataset(AsyncIterableDataset[int]):
+        def __init__(self) -> None:
+            super().__init__()
+
+            self.count = 0
+
+        def __aiter__(self) -> AsyncIterator[int]:
+            return self
+
+        async def __anext__(self) -> int:
+            self.count += 1
+            await asyncio.sleep(1e-2)
+            return self.count
+
+    ds = DummyDataset()
+    dl = DataLoader(ds, batch_size=4)
+
+    for frame in dl:
+        assert (frame == torch.tensor([1, 2, 3, 4])).all().item()
+        break


### PR DESCRIPTION
## Description

- Merge some async utils from another project into base template
- Async Iterable dataset: Allows using async functions in iterable
- read_video_with_timestamps_ffmpeg: Read video data using FFMPEG, getting the frame timestamps as well

## Test Plan

- Added a unit test for the new dataset

```bash
pytest tests/tasks/datasets/test_async_iterable.py
```
