### PR TITLE
Compile training loop to a single file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ __pycache__/
 build/
 dist/
 *.so
+out/
+

--- a/ml/core/config.py
+++ b/ml/core/config.py
@@ -41,7 +41,7 @@ def conf_field(
         return field(default=value, metadata=metadata)
 
 
-ConfigT = TypeVar("ConfigT", bound="BaseConfig")
+BaseConfigT = TypeVar("BaseConfigT", bound="BaseConfig")
 
 
 @dataclass
@@ -51,7 +51,7 @@ class BaseConfig:
     name: str = conf_field(MISSING, short="n", help="The referenced name of the object to construct")
 
     @classmethod
-    def get_defaults(cls: Type[ConfigT]) -> Dict[str, ConfigT]:
+    def get_defaults(cls: Type[BaseConfigT]) -> Dict[str, BaseConfigT]:
         """Returns default configurations.
 
         Returns:
@@ -61,7 +61,7 @@ class BaseConfig:
         return {}
 
     @classmethod
-    def resolve(cls: Type[ConfigT], config: ConfigT) -> None:
+    def resolve(cls: Type[BaseConfigT], config: BaseConfigT) -> None:
         """Runs post-construction config resolution.
 
         Args:
@@ -69,17 +69,17 @@ class BaseConfig:
         """
 
 
-class BaseObject(Generic[ConfigT]):
+class BaseObject(Generic[BaseConfigT]):
     """Defines the base class for all objects."""
 
-    def __init__(self, config: ConfigT) -> None:
-        self.config: ConfigT = config
+    def __init__(self, config: BaseConfigT) -> None:
+        self.config: BaseConfigT = config
 
 
-class BaseObjectWithPointers(BaseObject[ConfigT], Generic[ConfigT]):
+class BaseObjectWithPointers(BaseObject[BaseConfigT], Generic[BaseConfigT]):
     """Defines the base class for all objects with pointers to other objects."""
 
-    def __init__(self, config: ConfigT) -> None:
+    def __init__(self, config: BaseConfigT) -> None:
         super().__init__(config)
 
         self._raw_config: Optional[DictConfig] = None

--- a/ml/core/env.py
+++ b/ml/core/env.py
@@ -129,8 +129,8 @@ set_model_dir = ModelDir.set
 
 # The global random seed.
 RandomSeed = _IntEnvVar("RANDOM_SEED", default=1337)
-get_random_seed = RandomSeed.get
-set_random_seed = RandomSeed.set
+get_env_random_seed = RandomSeed.get
+set_env_random_seed = RandomSeed.set
 
 # Directory where code is staged before running large-scale experiments.
 StageDir = _PathEnvVar("STAGE_DIR")

--- a/ml/scripts/compiler.py
+++ b/ml/scripts/compiler.py
@@ -1,0 +1,22 @@
+import logging
+from pathlib import Path
+
+from omegaconf import DictConfig
+
+from ml.utils.compiler import compile_training_loop
+
+logger = logging.getLogger(__name__)
+
+
+def compile_main(config: DictConfig) -> None:
+    """Compiles the training loop into a single file."""  # noqa
+
+    # Gets a unique output file path.
+    out_path = Path.cwd() / "out" / "train.py"
+    index = 1
+    while out_path.exists():
+        index += 1
+        out_path = Path.cwd() / "out" / f"train_{index}.py"
+
+    compile_training_loop(config, out_path)
+    logger.info("Compiled to %s", out_path)

--- a/ml/scripts/mp_train.py
+++ b/ml/scripts/mp_train.py
@@ -7,17 +7,9 @@ from ml.core.registry import register_trainer
 logger = logging.getLogger(__name__)
 
 
-def main(config: DictConfig) -> None:
-    """Runs the training loop in a subprocess.
-
-    Args:
-        config: The raw config
-    """
+def mp_train_main(config: DictConfig) -> None:
+    """Runs the training loop in a subprocess."""  # noqa
 
     trainer = register_trainer.build_entry(config)
     assert trainer is not None, "Trainer is required to launch multiprocessing jobs"
     trainer.launch()
-
-
-if __name__ == "__main__":
-    raise RuntimeError("Don't run this script directly; run `cli.py mp_train ...` instead")

--- a/ml/scripts/stage.py
+++ b/ml/scripts/stage.py
@@ -7,12 +7,8 @@ from ml.core.registry import stage_environment
 logger = logging.getLogger(__name__)
 
 
-def main(config: DictConfig) -> None:
-    """Stages the current configuration.
-
-    Args:
-        config: The raw config
-    """
+def stage_main(config: DictConfig) -> None:
+    """Stages the current configuration."""  # noqa
 
     # Stages the currently-imported files.
     out_dir = stage_environment()
@@ -25,7 +21,3 @@ def main(config: DictConfig) -> None:
     config_path = config_dir / f"config_{config_id}.yaml"
     OmegaConf.save(config, config_path)
     logger.info("Staged config to %s", config_path)
-
-
-if __name__ == "__main__":
-    raise RuntimeError("Don't run this script directly; run `cli.py stage ...` instead")

--- a/ml/scripts/train.py
+++ b/ml/scripts/train.py
@@ -6,12 +6,8 @@ from ml.utils.timer import Timer
 logger = logging.getLogger(__name__)
 
 
-def main(objs: Objects) -> None:
-    """Runs the training loop.
-
-    Args:
-        objs: The parsed objects
-    """
+def train_main(objs: Objects) -> None:
+    """Runs the training loop."""  # noqa
 
     # Checks that the config has the right keys for training.
     assert (model := objs.model) is not None
@@ -23,7 +19,3 @@ def main(objs: Objects) -> None:
     # Runs the training loop.
     with Timer("running training loop"):
         trainer.train(model, task, optimizer, lr_scheduler)
-
-
-if __name__ == "__main__":
-    raise RuntimeError("Don't run this script directly; run `cli.py train ...` instead")

--- a/ml/tasks/cifar_demo.py
+++ b/ml/tasks/cifar_demo.py
@@ -6,16 +6,17 @@ import torchvision
 from torch import Tensor
 from torch.utils.data.dataset import Dataset
 
-from ml import api
+import ml.api as M
+from ml.api import register_task
 
 
 @dataclass
-class CIFARDemoTaskConfig(api.BaseTaskConfig):
+class CIFARDemoTaskConfig(M.BaseTaskConfig):
     pass
 
 
-@api.register_task("cifar_demo", CIFARDemoTaskConfig)
-class CIFARDemoTask(api.BaseTask[CIFARDemoTaskConfig]):
+@register_task("cifar_demo", CIFARDemoTaskConfig)
+class CIFARDemoTask(M.BaseTask[CIFARDemoTaskConfig]):
     def __init__(self, config: CIFARDemoTaskConfig) -> None:
         super().__init__(config)
 
@@ -33,18 +34,18 @@ class CIFARDemoTask(api.BaseTask[CIFARDemoTaskConfig]):
 
     def run_model(
         self,
-        model: api.BaseModel,
+        model: M.BaseModel,
         batch: Tuple[Tensor, Tensor],
-        state: api.State,
+        state: M.State,
     ) -> Tensor:
         image, _ = batch
         return model(image)
 
     def compute_loss(
         self,
-        model: api.BaseModel,
+        model: M.BaseModel,
         batch: Tuple[Tensor, Tensor],
-        state: api.State,
+        state: M.State,
         output: Tensor,
     ) -> Tensor:
         (image, classes), preds = batch, output
@@ -63,9 +64,9 @@ class CIFARDemoTask(api.BaseTask[CIFARDemoTaskConfig]):
 
         return F.cross_entropy(preds, classes.flatten().long(), reduction="none")
 
-    def get_dataset(self, phase: api.Phase) -> Dataset:
+    def get_dataset(self, phase: M.Phase) -> Dataset:
         return torchvision.datasets.CIFAR10(
-            root=api.get_data_dir(),
+            root=M.get_data_dir(),
             train=phase == "train",
             download=True,
         )

--- a/ml/tasks/datasets/collate.py
+++ b/ml/tasks/datasets/collate.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, List, Literal
 import numpy as np
 import torch
 import torchvision.transforms.functional as V
-from PIL.Image import Image
+from PIL.Image import Image as PILImage
 from torch import Tensor
 
 CollateMode = Literal["stack", "concat"]
@@ -149,7 +149,7 @@ def collate(
         return collate([torch.from_numpy(i) for i in items], mode=mode, pad=pad)
 
     # All images are converted to tensors.
-    if isinstance(item, Image):
+    if isinstance(item, PILImage):
         return collate([V.to_tensor(i) for i in items], mode=mode, pad=pad)
 
     # Numbers are converted to a list of tensors.

--- a/ml/trainers/ddp.py
+++ b/ml/trainers/ddp.py
@@ -35,7 +35,7 @@ from torch import nn
 from ml.core.env import get_distributed_backend
 from ml.core.registry import Objects, register_trainer
 from ml.models.base import BaseModel
-from ml.scripts.train import train_main as train_main
+from ml.scripts.train import train_main
 from ml.tasks.base import BaseTask
 from ml.trainers.base import MultiprocessConfig
 from ml.trainers.vanilla import VanillaTrainer, VanillaTrainerConfig

--- a/ml/trainers/ddp.py
+++ b/ml/trainers/ddp.py
@@ -35,7 +35,7 @@ from torch import nn
 from ml.core.env import get_distributed_backend
 from ml.core.registry import Objects, register_trainer
 from ml.models.base import BaseModel
-from ml.scripts.train import main as train_main
+from ml.scripts.train import train_main as train_main
 from ml.tasks.base import BaseTask
 from ml.trainers.base import MultiprocessConfig
 from ml.trainers.vanilla import VanillaTrainer, VanillaTrainerConfig

--- a/ml/trainers/mixins/cpu_stats.py
+++ b/ml/trainers/mixins/cpu_stats.py
@@ -50,8 +50,8 @@ def worker(config: CPUStatsConfigT, queue: "mp.Queue[CPUStats]", pid: int) -> No
                 num_child_procs=len(child_procs),
             )
             queue.put(cpu_stats)
-        except Exception:
-            logger.exception("Exception while getting CPU stats")
+        except psutil.NoSuchProcess:
+            logger.info("No parent process; probably cleaning up")
         time.sleep(config.ping_interval)
 
 

--- a/ml/trainers/mixins/cpu_stats.py
+++ b/ml/trainers/mixins/cpu_stats.py
@@ -52,8 +52,8 @@ def worker(config: CPUStatsConfigT, queue: "mp.Queue[CPUStats]", pid: int) -> No
             cpu_stats = CPUStats(
                 cpu_percent=proc.cpu_percent(),
                 mem_percent=proc.memory_percent(),
-                max_child_cpu_percent=max(p.cpu_percent() for p in child_procs.values()),
-                max_child_mem_percent=max(p.memory_percent() for p in child_procs.values()),
+                max_child_cpu_percent=max(p.cpu_percent() for p in child_procs.values()) if child_procs else 0.0,
+                max_child_mem_percent=max(p.memory_percent() for p in child_procs.values()) if child_procs else 0.0,
                 num_child_procs=len(child_procs),
             )
             queue.put(cpu_stats)

--- a/ml/trainers/mixins/cpu_stats.py
+++ b/ml/trainers/mixins/cpu_stats.py
@@ -25,7 +25,7 @@ class CPUStatsConfig(BaseTrainerConfig):
     ping_interval: int = conf_field(1, help="How often to check stats (in seconds)")
 
 
-ConfigT = TypeVar("ConfigT", bound=CPUStatsConfig)
+CPUStatsConfigT = TypeVar("CPUStatsConfigT", bound=CPUStatsConfig)
 
 
 @dataclass(frozen=True)
@@ -37,7 +37,7 @@ class CPUStats:
     num_child_procs: int
 
 
-def worker(config: ConfigT, queue: "mp.Queue[CPUStats]", pid: int) -> None:
+def worker(config: CPUStatsConfigT, queue: "mp.Queue[CPUStats]", pid: int) -> None:
     while True:
         try:
             proc = psutil.Process(pid)
@@ -55,10 +55,10 @@ def worker(config: ConfigT, queue: "mp.Queue[CPUStats]", pid: int) -> None:
         time.sleep(config.ping_interval)
 
 
-class CPUStatsMixin(BaseTrainer[ConfigT]):
+class CPUStatsMixin(BaseTrainer[CPUStatsConfigT]):
     """Defines a trainer mixin for getting CPU statistics."""
 
-    def __init__(self, config: ConfigT) -> None:
+    def __init__(self, config: CPUStatsConfigT) -> None:
         super().__init__(config)
 
         self._cpu_stats: Optional[CPUStats] = None

--- a/ml/trainers/mixins/grad_clipping.py
+++ b/ml/trainers/mixins/grad_clipping.py
@@ -27,7 +27,7 @@ class GradientClippingConfig(MixedPrecisionTrainerConfig, BaseTrainerConfig):
     grad_clipping: GradientClipping = GradientClipping()
 
 
-ConfigT = TypeVar("ConfigT", bound=GradientClippingConfig)
+GradientClippingConfigT = TypeVar("GradientClippingConfigT", bound=GradientClippingConfig)
 
 
 def get_clip_grad_func(clip_value: float) -> Callable[[Tensor], Tensor]:
@@ -46,8 +46,8 @@ def get_clip_norm_func(clip_value: float, norm_type: Any) -> Callable[[Tensor], 
 
 
 class GradientClippingTrainerMixin(
-    MixedPrecisionTrainerMixin[ConfigT],
-    BaseTrainer[ConfigT],
+    MixedPrecisionTrainerMixin[GradientClippingConfigT],
+    BaseTrainer[GradientClippingConfigT],
 ):
     """Defines a trainer mixin for doing gradient clipping."""
 

--- a/ml/trainers/mixins/mixed_precision.py
+++ b/ml/trainers/mixins/mixed_precision.py
@@ -23,13 +23,13 @@ class MixedPrecisionTrainerConfig(BaseTrainerConfig):
     fp16: FP16 = FP16()
 
 
-ConfigT = TypeVar("ConfigT", bound=MixedPrecisionTrainerConfig)
+MixedPrecisionConfigT = TypeVar("MixedPrecisionConfigT", bound=MixedPrecisionTrainerConfig)
 
 
-class MixedPrecisionTrainerMixin(BaseTrainer[ConfigT]):
+class MixedPrecisionTrainerMixin(BaseTrainer[MixedPrecisionConfigT]):
     """Defines a trainer mixin for doing FP16 scaling."""
 
-    def __init__(self, config: ConfigT) -> None:
+    def __init__(self, config: MixedPrecisionConfigT) -> None:
         super().__init__(config)
 
         self.grad_scaler: torch.cuda.amp.GradScaler | None

--- a/ml/trainers/mixins/profiler.py
+++ b/ml/trainers/mixins/profiler.py
@@ -52,16 +52,16 @@ class ProfilerTrainerConfig(BaseTrainerConfig):
     profiler: Profiler = Profiler()
 
 
-ConfigT = TypeVar("ConfigT", bound=ProfilerTrainerConfig)
+ProfilerTrainerConfigT = TypeVar("ProfilerTrainerConfigT", bound=ProfilerTrainerConfig)
 
 
 class ProfilerTrainerMixin(
-    StepContextMixin[ConfigT],
-    BaseTrainer[ConfigT],
+    StepContextMixin[ProfilerTrainerConfigT],
+    BaseTrainer[ProfilerTrainerConfigT],
 ):
     """Defines a trainer mixin for enabling the PyTorch profiler."""
 
-    def __init__(self, config: ConfigT) -> None:
+    def __init__(self, config: ProfilerTrainerConfigT) -> None:
         super().__init__(config)
 
         self.step_times: Dict[StepType, float] = {}

--- a/ml/trainers/mixins/step_wrapper.py
+++ b/ml/trainers/mixins/step_wrapper.py
@@ -22,7 +22,7 @@ StepType = Literal[
 ]
 
 
-ConfigT = TypeVar("ConfigT", bound=BaseTrainerConfig)
+BaseTrainerConfigT = TypeVar("BaseTrainerConfigT", bound=BaseTrainerConfig)
 
 
 class StepContext(ContextManager):
@@ -45,6 +45,6 @@ class StepContext(ContextManager):
         StepContext.CURRENT_STEP = None
 
 
-class StepContextMixin(BaseTrainer[ConfigT], ABC):
+class StepContextMixin(BaseTrainer[BaseTrainerConfigT], ABC):
     def step_context(self, step: StepType) -> ContextManager:
         return StepContext(step)

--- a/ml/trainers/slurm.py
+++ b/ml/trainers/slurm.py
@@ -36,7 +36,7 @@ from ml.core.registry import Objects, register_trainer, stage_environment
 from ml.core.state import State
 from ml.lr_schedulers.base import SchedulerAdapter
 from ml.models.base import BaseModel
-from ml.scripts.train import main as train_main
+from ml.scripts.train import train_main
 from ml.tasks.base import BaseTask
 from ml.trainers.vanilla import VanillaTrainer, VanillaTrainerConfig
 from ml.utils.distributed import (

--- a/ml/trainers/slurm.py
+++ b/ml/trainers/slurm.py
@@ -42,7 +42,7 @@ from ml.trainers.vanilla import VanillaTrainer, VanillaTrainerConfig
 from ml.utils.distributed import (
     get_master_addr,
     get_master_port,
-    get_world_size,g
+    get_world_size,
     init_process_group,
     is_master,
     set_init_method,

--- a/ml/trainers/slurm.py
+++ b/ml/trainers/slurm.py
@@ -42,7 +42,7 @@ from ml.trainers.vanilla import VanillaTrainer, VanillaTrainerConfig
 from ml.utils.distributed import (
     get_master_addr,
     get_master_port,
-    get_world_size,
+    get_world_size,g
     init_process_group,
     is_master,
     set_init_method,

--- a/ml/utils/call_train.py
+++ b/ml/utils/call_train.py
@@ -1,0 +1,36 @@
+import sys
+
+from ml.core.env import add_global_tag
+from ml.core.registry import Objects
+from ml.scripts.train import train_main
+from ml.utils.cli import parse_cli
+from ml.utils.distributed import get_rank_optional, get_world_size_optional
+from ml.utils.logging import configure_logging
+
+
+def call_train() -> None:
+    configure_logging(rank=get_rank_optional(), world_size=get_world_size_optional())
+
+    def show_help() -> None:
+        print("Usage: train /path/to/config.yaml", file=sys.stderr)
+        sys.exit(1)
+
+    # Parses the raw command line options.
+    args = sys.argv[1:]
+    if len(args) == 0:
+        show_help()
+
+    # Adds a global tag with the currently-selected option.
+    add_global_tag("train")
+
+    # Resolves the config to the correct objects.
+    config = parse_cli(args)
+    Objects.resolve_config(config)
+    objs = Objects.parse_raw_config(config)
+
+    # Calls main training loop.
+    train_main(objs)
+
+
+if __name__ == "__main__":
+    call_train()

--- a/ml/utils/cli.py
+++ b/ml/utils/cli.py
@@ -1,0 +1,83 @@
+import logging
+import sys
+from functools import partial
+from pathlib import Path
+from typing import List, Optional, Set, cast
+
+from omegaconf import DictConfig, OmegaConf
+
+from ml.core.env import get_global_tags, set_exp_name
+
+logger = logging.getLogger(__name__)
+
+
+IGNORE_ARGS: Set[str] = {
+    "trainer.exp_name",
+    "trainer.log_dir_name",
+    "trainer.base_run_dir",
+    "trainer.run_id",
+    "trainer.name",
+}
+
+
+def get_exp_name(prefix: Optional[str] = None, args: Optional[List[str]] = None) -> str:
+    parts: List[str] = []
+    if prefix is not None:
+        parts += [prefix]
+    if args is not None:
+        parts += args
+    if not parts:
+        parts = ["run"]
+    parts += get_global_tags()
+    return ".".join(p for p in parts if p)
+
+
+def parse_cli(args: List[str]) -> DictConfig:
+    """Parses the remaining command-line arguments to a raw config.
+
+    Args:
+        args: The raw command-line arguments to parse
+
+    Returns:
+        The raw config, loaded from the provided arguments
+    """
+
+    def show_help() -> None:
+        print("Usage: cmd <path/to/config.yaml> [<new_config.yaml>, ...] overrida.a=1 override.b=2", file=sys.stderr)
+        sys.exit(1)
+
+    if len(args) == 0 or "-h" in args or "--help" in args:
+        show_help()
+
+    # Builds the configs from the command-line arguments.
+    config = DictConfig({})
+    get_stem = lambda new_path: Path(new_path).stem
+    argument_parts: List[str] = []
+    paths: List[Path] = []
+
+    # Parses all of the config paths.
+    while len(args) > 0 and (args[0].endswith(".yaml") or args[0].endswith(".yml")):
+        paths, new_stem, args = paths + [Path(args[0])], get_stem(args[0]), args[1:]
+        argument_parts.append(new_stem)
+
+    # Parses all of the additional config overrides.
+    if len(args) > 0:
+        split_args = [a.split("=") for a in args]
+        assert all(len(a) == 2 for a in split_args), f"Got invalid arguments: {[a for a in split_args if len(a) != 2]}"
+        argument_parts += [f"{k.split('.')[-1]}_{v}" for k, v in sorted(split_args) if k not in IGNORE_ARGS]
+
+    # Registers an OmegaConf resolver with the job name.
+    if not OmegaConf.has_resolver("exp_name"):
+        OmegaConf.register_new_resolver("exp_name", partial(get_exp_name, args=argument_parts))
+    set_exp_name(get_exp_name(args=argument_parts))
+
+    # Finally, builds the config.
+    try:
+        for path in paths:
+            config = cast(DictConfig, OmegaConf.merge(config, OmegaConf.load(path)))
+        config = cast(DictConfig, OmegaConf.merge(config, OmegaConf.from_dotlist(args)))
+    except Exception:
+        logger.exception("Error while creating dotlist")
+        show_help()
+
+    return config

--- a/ml/utils/compiler.py
+++ b/ml/utils/compiler.py
@@ -1,0 +1,314 @@
+import ast
+import functools
+import inspect
+import logging
+import sys
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Deque, Dict, Iterator, List, Set, Tuple, Type
+
+from omegaconf import DictConfig
+
+from ml.core.registry import (
+    NAME_KEY,
+    multi_register_base,
+    register_base,
+    register_logger,
+    register_lr_scheduler,
+    register_model,
+    register_optimizer,
+    register_task,
+    register_trainer,
+)
+from ml.utils.call_train import call_train
+
+logger = logging.getLogger(__name__)
+
+ROOT_PATH = Path(__file__).parent.parent.parent
+BASE_NAME = __name__.split(".", maxsplit=1)[0]
+BASE_MODULE_PREFIX = f"{BASE_NAME}."
+
+
+def lookup_path(config: DictConfig, registry: Type[register_base]) -> Path:
+    if registry.config_key() not in config:
+        raise KeyError(f"Key '{registry.config_key()}' not found in config")
+    if NAME_KEY not in config[registry.config_key()]:
+        raise KeyError(f"'{NAME_KEY}' not found in {registry.config_key()} config")
+    return registry.lookup_path(config[registry.config_key()][NAME_KEY])
+
+
+def lookup_paths(config: DictConfig, registry: Type[multi_register_base]) -> List[Path]:
+    if registry.config_key() not in config:
+        raise KeyError(f"Key '{registry.config_key()}' not found in config")
+    paths: List[Path] = []
+    for subconfig in config[registry.config_key()]:
+        if NAME_KEY not in subconfig:
+            raise KeyError(f"'{NAME_KEY}' not found in {registry.config_key()} config")
+        paths.append(registry.lookup_path(subconfig[NAME_KEY]))
+    return paths
+
+
+def get_loc_str(path: str | Path, node: ast.AST) -> str:
+    return f"{path}:{node.lineno}:{node.col_offset}"
+
+
+@dataclass(frozen=True)
+class ImportItem:
+    module: str
+    name: str | None
+    asname: str | None
+
+
+def toposort(data: Dict[str, Set[str]]) -> Iterator[str]:
+    if len(data) == 0:
+        return
+    data = {item: set(e for e in dep if e != item) for item, dep in data.items()}
+    extra_items_in_deps = functools.reduce(set.union, data.values()) - set(data.keys())
+    data.update({item: set() for item in extra_items_in_deps})
+    while True:
+        ordered = set(item for item, dep in data.items() if len(dep) == 0)
+        if not ordered:
+            break
+        yield from ordered
+        data = {item: (dep - ordered) for item, dep in data.items() if item not in ordered}
+    if data:
+        raise RuntimeError("Found circular dependencies!")
+
+
+@functools.lru_cache
+def api_import_stmts() -> Dict[str, ast.ImportFrom]:
+    api_path = ROOT_PATH / BASE_NAME / "api.py"
+
+    with open(api_path, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read())
+
+    stmts: Dict[str, ast.ImportFrom] = {}
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Import):
+            raise NotImplementedError("API should only have `from ... import ...` statements")
+        if isinstance(stmt, ast.ImportFrom):
+            for alias in stmt.names:
+                key = alias.name if alias.asname is None else alias.asname
+                stmts[key] = ast.ImportFrom(module=stmt.module, names=[alias], level=stmt.level)
+
+    return stmts
+
+
+def api_import_stmt(name: str, asname: str | None) -> ast.ImportFrom:
+    stmt = api_import_stmts()[name]
+    return ast.ImportFrom(module=stmt.module, names=[ast.alias(name=name, asname=asname)], level=stmt.level)
+
+
+def replace_expr(base: ast.stmt, from_expr: ast.expr, to_expr: ast.expr) -> None:
+    for field in base._fields:
+        field_val = getattr(base, field)
+        if field_val == from_expr:
+            setattr(base, field, to_expr)
+            break
+        if isinstance(field_val, list):
+            setattr(base, field, [to_expr if i == from_expr else i for i in field_val])
+            break
+    else:
+        raise ValueError("Error while replacing expression")
+
+
+def remove_api(api_name: str, tree: ast.AST) -> Set[ast.ImportFrom]:
+    api_modules: Set[str] = set()
+
+    todo: "Deque[ast.AST]" = deque([tree])
+    while todo:
+        node = todo.popleft()
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id == api_name:
+            new_node = ast.Name(id=node.attr)
+            replace_expr(node.parent, node, new_node)
+            api_modules.add(node.attr)
+        for child in ast.iter_child_nodes(node):
+            child.parent = node
+            todo.append(child)
+
+    return {api_import_stmt(c, None) for c in api_modules}
+
+
+def preprocess_stmt(stmt: ast.stmt, tree: ast.AST) -> Iterator[ast.stmt]:
+    if isinstance(stmt, ast.Import):
+        for name in stmt.names:
+            if name.name == f"{BASE_NAME}.api":
+                yield from remove_api(name.name if name.asname is None else name.asname, tree)
+            else:
+                yield ast.Import(names=[name])
+    elif isinstance(stmt, ast.ImportFrom):
+        if stmt.module == BASE_NAME:
+            for name in stmt.names:
+                if name.name == "api":
+                    yield from remove_api(name.name if name.asname is None else name.asname, tree)
+        elif stmt.module == f"{BASE_NAME}.api":
+            for name in stmt.names:
+                yield api_import_stmt(name.name, name.asname)
+        else:
+            yield stmt
+    else:
+        yield stmt
+
+
+def get_import_dag_for(
+    path: Path,
+    path_mod_names: Dict[Path, str],
+    all_other_imports: Set[ImportItem],
+    deps: Dict[str, Set[str]],
+) -> None:
+    mod_name = path_mod_names[path]
+    if mod_name in deps:
+        return
+    deps[mod_name] = set()
+
+    # Gets the module dag.
+    with open(path, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=str(path))
+
+    def process_stmt(stmt: ast.stmt) -> None:
+        if isinstance(stmt, ast.Import):
+            for name in stmt.names:
+                if name.name == BASE_NAME or name.name.startswith(BASE_MODULE_PREFIX):
+                    deps[mod_name].add(name.name)
+                    mod_path = Path(inspect.getfile(sys.modules[name.name]))
+                    get_import_dag_for(mod_path, path_mod_names, all_other_imports, deps)
+                else:
+                    all_other_imports.add(ImportItem(module=name.name, name=None, asname=name.asname))
+        elif isinstance(stmt, ast.ImportFrom):
+            if stmt.module is None or stmt.module.startswith("."):
+                raise RuntimeError(f"Cannot compile program with relative imports: {get_loc_str(path, stmt)}")
+            if stmt.module == BASE_NAME or stmt.module.startswith(BASE_MODULE_PREFIX):
+                if stmt.module not in sys.modules:
+                    raise RuntimeError(f"Module '{stmt.module}' has not been imported")
+                deps[mod_name].add(stmt.module)
+                mod_path = Path(inspect.getfile(sys.modules[stmt.module]))
+                path_mod_names[mod_path] = stmt.module
+                get_import_dag_for(mod_path, path_mod_names, all_other_imports, deps)
+            else:
+                for name in stmt.names:
+                    all_other_imports.add(ImportItem(module=stmt.module, name=name.name, asname=name.asname))
+        elif isinstance(stmt, ast.If) and isinstance(stmt.test, ast.Name) and stmt.test.id == "TYPE_CHECKING":
+            pass
+        else:
+            for i in ast.walk(stmt):
+                if isinstance(i, (ast.ImportFrom, ast.Import)):
+                    raise RuntimeError(f"Cannot compile program with non-top level imports: {get_loc_str(path, i)}")
+
+    for stmt in (s for stmt in tree.body for s in preprocess_stmt(stmt, tree)):
+        process_stmt(stmt)
+
+
+def get_import_dag(paths: List[Path]) -> Tuple[Dict[str, Set[str]], Set[ImportItem]]:
+    all_other_imports: Set[ImportItem] = set()
+    deps: Dict[str, Set[str]] = {}
+    path_mod_names = {Path(inspect.getfile(v)): k for k, v in sys.modules.items() if k.startswith(BASE_MODULE_PREFIX)}
+    for path in paths:
+        get_import_dag_for(path, path_mod_names, all_other_imports, deps)
+    return deps, all_other_imports
+
+
+def get_import_code_block(imports: Set[ImportItem]) -> str:
+    """Builds a code block for the import statements.
+
+    Args:
+        imports: The set of all parsed import items
+
+    Returns:
+        A code block for the import statements
+    """
+
+    # Adds import statements.
+    body: List[ast.stmt] = []
+    import_names = (i for i in imports if i.name is None)
+    for name, asname in sorted({(i.module, i.asname) for i in import_names}):
+        body.append(ast.Import(names=[ast.alias(name=name, asname=asname)]))
+
+    # Adds import from lines.
+    import_from_map: Dict[str, Set[Tuple[str, str | None]]] = {i.module: set() for i in imports if i.name is not None}
+    for i in imports:
+        if i.name is not None:
+            import_from_map[i.module].add((i.name, i.asname))
+    for mod_name, items in sorted(import_from_map.items()):
+        if len(items) == 1:
+            name, asname = list(items)[0]
+            body.append(ast.ImportFrom(module=mod_name, names=[ast.alias(name=name, asname=asname)], level=0))
+        else:
+            import_from_node = ast.ImportFrom(module=mod_name, names=[], level=0)
+            for name, asname in items:
+                import_from_node.names.append(ast.alias(name=name, asname=asname))
+            body.append(import_from_node)
+
+    base = ast.Module(body=body, type_ignores=[])
+    return ast.unparse(base)
+
+
+def get_file_block(mod_path: Path) -> str:
+    with open(mod_path, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=str(mod_path))
+
+    new_stmts: List[ast.stmt] = []
+
+    for stmt in (s for stmt in tree.body for s in preprocess_stmt(stmt, tree)):
+        if isinstance(stmt, (ast.Import, ast.ImportFrom)):
+            continue
+        elif isinstance(stmt, ast.If) and isinstance(stmt.test, ast.Name) and stmt.test.id == "TYPE_CHECKING":
+            continue
+        else:
+            new_stmts.append(stmt)
+
+    return ast.unparse(ast.Module(body=new_stmts, type_ignores=[]))
+
+
+def make_title(title: str) -> str:
+    return "\n".join(["#" * (len(title) + 4), f"# {title} #", "#" * (len(title) + 4)])
+
+
+def get_full_file(deps: Dict[str, Set[str]], imports: Set[ImportItem]) -> str:
+    header = "#!/usr/bin/env python\n\n"
+
+    parts: List[Tuple[str, str]] = []
+    parts.append(("imports", get_import_code_block(imports)))
+
+    # Iterates through dependencies in topographical order.
+    for dep in toposort(deps):
+        mod_path = Path(inspect.getfile(sys.modules[dep]))
+        parts.append((str(mod_path.relative_to(ROOT_PATH)), get_file_block(mod_path)))
+
+    return header + "\n\n".join(f"{make_title(title)}\n\n{body}" for title, body in parts)
+
+
+def compile_training_loop(config: DictConfig, out_path: Path) -> None:
+    """Compiles the full training loop to a single file.
+
+    Args:
+        config: The training config
+        out_path: The path to the output file
+    """
+
+    model_path = lookup_path(config, register_model)
+    trainer_path = lookup_path(config, register_trainer)
+    task_path = lookup_path(config, register_task)
+    optimizer_path = lookup_path(config, register_optimizer)
+    lr_scheduler_path = lookup_path(config, register_lr_scheduler)
+    logger_paths = lookup_paths(config, register_logger)
+    call_train_path = Path(inspect.getfile(call_train))
+    call_train_mod = f"{BASE_NAME}.utils.call_train"
+
+    paths = logger_paths + [optimizer_path, lr_scheduler_path, trainer_path, task_path, model_path, call_train_path]
+    deps, all_other_imports = get_import_dag(paths)
+    deps[call_train_mod].update(i for i in deps if i != call_train_mod)
+    full_file = get_full_file(deps, all_other_imports)
+
+    # If black is installed, format the raw file contents.
+    try:
+        import black  # pylint: disable=import-outside-toplevel
+
+        full_file = black.format_file_contents(full_file, fast=True, mode=black.FileMode())
+    except ModuleNotFoundError:
+        pass
+
+    out_path.parent.mkdir(exist_ok=True, parents=True)
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(full_file)

--- a/ml/utils/random.py
+++ b/ml/utils/random.py
@@ -4,12 +4,12 @@ from typing import Optional
 import numpy as np
 import torch
 
-from ml.core.env import get_random_seed
+from ml.core.env import get_env_random_seed
 
 
 def set_random_seed(seed: Optional[int] = None, offset: int = 0) -> None:
     if seed is None:
-        seed = get_random_seed()
+        seed = get_env_random_seed()
     seed += offset
     random.seed(seed)
     np.random.seed(seed)

--- a/ml/utils/timer.py
+++ b/ml/utils/timer.py
@@ -57,7 +57,7 @@ def timeout(seconds: int, error_message: str = os.strerror(errno.ETIME)) -> Call
         Decorator function
     """
 
-    def decorator(func: F) -> F:
+    def decorator(func: TimeoutFunc) -> TimeoutFunc:
         def _handle_timeout(*_: Any) -> None:
             raise TimeoutError(error_message)
 

--- a/ml/utils/timer.py
+++ b/ml/utils/timer.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Optional, TypeVar
 
 logger = logging.getLogger(__name__)
 
-F = TypeVar("F", bound=Callable[..., Any])
+TimeoutFunc = TypeVar("TimeoutFunc", bound=Callable[..., Any])
 
 
 class Timer:
@@ -36,7 +36,7 @@ class Timer:
             logger.warning("Finished %s in %.3g seconds", self.description, self._elapsed_time)
 
 
-def timeout(seconds: int, error_message: str = os.strerror(errno.ETIME)) -> Callable[[F], F]:
+def timeout(seconds: int, error_message: str = os.strerror(errno.ETIME)) -> Callable[[TimeoutFunc], TimeoutFunc]:
     """Decorator for timing out long-running functions.
 
     Note that this function won't work on Windows.

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,18 +2,9 @@
 
 max-line-length = 120
 
-exclude =
-    .git,
-    __pycache__,
-    build,
-    dist,
-    *.pyi
+exclude = .git, __pycache__, build, dist, *.pyi
 
-ignore =
-    E712,  # Comparison to false
-    E731,  # No lambda functions
-    E203,  # Whitespace before ':'
-    W503,  # Line break before binary operator
+ignore = E712, E731, E203, W503
 
 [options]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ exclude =
 
 # These are command-line scripts that get created.
 console_scripts =
-    ml = ml.scripts.cli:main
+    ml = ml.scripts.cli:cli_main


### PR DESCRIPTION
## Description

Adds a command-line tool to compile the training loop to a single file. This is an alternative to staging the entire workspace.

Some future ideas:

1. Write the config to the file as well to make it truly just one file
2. Automatically remove the registry stuff
3. Remove imported but unused functions

## Test Plan

- Training command

```bash
# Generates a single runnable Python file
ml compile configs/cifar_demo.yaml

# Runs the Python file using the associated config
python out/train.py configs/cifar_demo.yaml
```
